### PR TITLE
Add _PERPS_CANCEL_LIMIT_ORDER and _PERPS_COMMIT_OFFCHAIN_ORDER_PERMIS…

### DIFF
--- a/protocol/synthetix/contracts/storage/AccountRBAC.sol
+++ b/protocol/synthetix/contracts/storage/AccountRBAC.sol
@@ -63,6 +63,8 @@ library AccountRBAC {
             permission != AccountRBAC._PERPS_MODIFY_COLLATERAL_PERMISSION &&
             permission != AccountRBAC._PERPS_COMMIT_ASYNC_ORDER_PERMISSION &&
             permission != AccountRBAC._PERPS_COMMIT_LIMIT_ORDER_PERMISSION &&
+            permission != AccountRBAC._PERPS_COMMIT_OFFCHAIN_ORDER_PERMISSION &&
+            permission != AccountRBAC._PERPS_CANCEL_LIMIT_ORDER &&
             permission != AccountRBAC._BURN_PERMISSION &&
             permission != AccountRBAC._BFP_PERPS_PAY_DEBT_PERMISSION &&
             permission != AccountRBAC._BFP_PERPS_SPLIT_ACCOUNT_PERMISSION


### PR DESCRIPTION
…SION in valid permissions check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved invalid permission errors when committing off-chain perpetual orders and canceling limit orders. Users with the appropriate roles can now perform these actions without unexpected reverts, improving reliability and access control consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->