### PR TITLE
Accept fillSize while settling limit order

### DIFF
--- a/markets/perps-market/contracts/interfaces/IOffchainLimitOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IOffchainLimitOrderModule.sol
@@ -38,9 +38,5 @@ interface IOffchainLimitOrderModule {
 
     error InvalidFillSize(uint128 fillSize, uint128 shortAmount, uint128 longAmount);
 
-    error PartialMatchingNotAllowed(
-        uint128 fillSize,
-        uint128 shortRemaining,
-        uint128 longRemaining
-    );
+    error PartialMatchingNotAllowed(uint128 accountId, uint128 fillSize, uint128 sizeRemaining);
 }

--- a/markets/perps-market/contracts/interfaces/IOffchainLimitOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IOffchainLimitOrderModule.sol
@@ -12,6 +12,14 @@ interface IOffchainLimitOrderModule {
         OffchainOrder.Signature memory secondSignature
     ) external;
 
+    function settleOffchainLimitOrders(
+        OffchainOrder.Data memory firstOrder,
+        OffchainOrder.Signature memory firstSignature,
+        OffchainOrder.Data memory secondOrder,
+        OffchainOrder.Signature memory secondSignature,
+        uint128 fillSize
+    ) external;
+
     /**
      * @notice cancels a limit order, can only be called by an account with the permission to cancel
      * @param accountId limit order account id
@@ -27,4 +35,12 @@ interface IOffchainLimitOrderModule {
     event LimitOrderCancelled(uint128 indexed accountId, uint256 limitOrderNonce);
 
     error LimitOrderAlreadyUsed(uint128 accountId, uint256 limitOrderNonce);
+
+    error InvalidFillSize(uint128 fillSize, uint128 shortAmount, uint128 longAmount);
+
+    error PartialMatchingNotAllowed(
+        uint128 fillSize,
+        uint128 shortRemaining,
+        uint128 longRemaining
+    );
 }

--- a/markets/perps-market/contracts/interfaces/PythLazer/IOffchainLimitOrderPythLazerModule.sol
+++ b/markets/perps-market/contracts/interfaces/PythLazer/IOffchainLimitOrderPythLazerModule.sol
@@ -19,9 +19,5 @@ interface IOffchainLimitOrderPythLazerModule {
 
     error InvalidFillSize(uint128 fillSize, uint128 shortAmount, uint128 longAmount);
 
-    error PartialMatchingNotAllowed(
-        uint128 fillSize,
-        uint128 shortRemaining,
-        uint128 longRemaining
-    );
+    error PartialMatchingNotAllowed(uint128 accountId, uint128 fillSize, uint128 sizeRemaining);
 }

--- a/markets/perps-market/contracts/interfaces/PythLazer/IOffchainLimitOrderPythLazerModule.sol
+++ b/markets/perps-market/contracts/interfaces/PythLazer/IOffchainLimitOrderPythLazerModule.sol
@@ -9,10 +9,19 @@ interface IOffchainLimitOrderPythLazerModule {
         OffchainOrder.Data memory firstOrder,
         OffchainOrder.Signature memory firstSignature,
         OffchainOrder.Data memory secondOrder,
-        OffchainOrder.Signature memory secondSignature
+        OffchainOrder.Signature memory secondSignature,
+        uint128 fillSize
     ) external;
 
     event LimitOrderCancelled(uint128 indexed accountId, uint256 limitOrderNonce);
 
     error LimitOrderAlreadyUsed(uint128 accountId, uint256 limitOrderNonce);
+
+    error InvalidFillSize(uint128 fillSize, uint128 shortAmount, uint128 longAmount);
+
+    error PartialMatchingNotAllowed(
+        uint128 fillSize,
+        uint128 shortRemaining,
+        uint128 longRemaining
+    );
 }

--- a/markets/perps-market/contracts/modules/OffchainLimitOrderModule.sol
+++ b/markets/perps-market/contracts/modules/OffchainLimitOrderModule.sol
@@ -361,13 +361,13 @@ contract OffchainLimitOrderModule is IOffchainLimitOrderModule, IMarketEvents, I
 
         if (fillSize < shortRemaining) {
             if (!shortOrder.allowPartialMatching) {
-                revert PartialMatchingNotAllowed(fillSize, shortRemaining, longRemaining);
+                revert PartialMatchingNotAllowed(shortOrder.accountId, fillSize, shortRemaining);
             }
             firstOrderPartialFill = true;
         }
         if (fillSize < longRemaining) {
             if (!longOrder.allowPartialMatching) {
-                revert PartialMatchingNotAllowed(fillSize, shortRemaining, longRemaining);
+                revert PartialMatchingNotAllowed(longOrder.accountId, fillSize, longRemaining);
             }
             secondOrderPartialFill = true;
         }

--- a/markets/perps-market/contracts/modules/PythLazer/OffchainLimitOrderPythLazerModule.sol
+++ b/markets/perps-market/contracts/modules/PythLazer/OffchainLimitOrderPythLazerModule.sol
@@ -169,13 +169,13 @@ contract OffchainLimitOrderPythLazerModule is
 
         if (fillSize < shortRemaining) {
             if (!shortOrder.allowPartialMatching) {
-                revert PartialMatchingNotAllowed(fillSize, shortRemaining, longRemaining);
+                revert PartialMatchingNotAllowed(shortOrder.accountId, fillSize, shortRemaining);
             }
             firstOrderPartialFill = true;
         }
         if (fillSize < longRemaining) {
             if (!longOrder.allowPartialMatching) {
-                revert PartialMatchingNotAllowed(fillSize, shortRemaining, longRemaining);
+                revert PartialMatchingNotAllowed(longOrder.accountId, fillSize, longRemaining);
             }
             secondOrderPartialFill = true;
         }

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -174,7 +174,11 @@ library AsyncOrder {
                 .size;
 
             if (MathUtil.sameSide(currentSize, newRequest.sizeDelta)) {
-                revert OffchainOrder.ReduceOnlyOrder(currentSize, newRequest.sizeDelta);
+                revert OffchainOrder.ReduceOnlyOrder(
+                    newRequest.accountId,
+                    currentSize,
+                    newRequest.sizeDelta
+                );
             }
 
             if (MathUtil.abs(currentSize) <= MathUtil.abs(newRequest.sizeDelta)) {

--- a/markets/perps-market/contracts/storage/OffchainOrder.sol
+++ b/markets/perps-market/contracts/storage/OffchainOrder.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.11 <0.9.0;
 
 library OffchainOrder {
-    error ReduceOnlyOrder(int128 currentSize, int128 sizeDelta);
+    error ReduceOnlyOrder(uint128 accountId, int128 currentSize, int128 sizeDelta);
 
     struct TpSlSettings {
         uint256 tpPriceA;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for settling two off-chain limit orders simultaneously
  * Introduced fill size parameter for more granular order settlement
  * Enhanced partial matching and reduce-only order handling

* **Bug Fixes**
  * Improved error handling for order settlement scenarios
  * Added validation for fill sizes and partial matching constraints

* **Improvements**
  * Updated error reporting to include more context (account ID)
  * Refined limit order amount update mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->