### PR TITLE
Remove settlement fee for zero-fee markets

### DIFF
--- a/markets/perps-market/contracts/modules/AsyncOrderSettlementPythModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderSettlementPythModule.sol
@@ -111,10 +111,11 @@ contract AsyncOrderSettlementPythModule is
         runtime.updateData = _processPositionUpdate(price, runtime, market, originalMarketSize);
         perpsAccount.updateOpenPositions(runtime.marketId, runtime.newPosition.size);
 
-        runtime.settlementReward = AsyncOrder.settlementRewardCost(settlementStrategy);
-
-        // Process fees
-        _processFees(runtime, asyncOrder, factory);
+        if (runtime.totalFees > 0) {
+            runtime.settlementReward = AsyncOrder.settlementRewardCost(settlementStrategy);
+            // Process fees
+            _processFees(runtime, asyncOrder, factory);
+        }
 
         // Emit events in a helper function
         _emitSettlementEvents(runtime, asyncOrder);

--- a/markets/perps-market/contracts/modules/OffchainAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/OffchainAsyncOrderModule.sol
@@ -169,10 +169,11 @@ contract OffchainAsyncOrderModule is IOffchainAsyncOrderModule, IMarketEvents, I
         runtime.updateData = processPositionUpdate(price, runtime, market, originalMarketSize);
         perpsAccount.updateOpenPositions(runtime.marketId, runtime.newPosition.size);
 
-        runtime.settlementReward = AsyncOrder.settlementRewardCost(settlementStrategy);
-
-        // Process fees
-        processFees(runtime, asyncOrder, factory);
+        if (runtime.totalFees > 0) {
+            runtime.settlementReward = AsyncOrder.settlementRewardCost(settlementStrategy);
+            // Process fees
+            processFees(runtime, asyncOrder, factory);
+        }
 
         // Emit events in a helper function
         emitSettlementEvents(runtime, asyncOrder);

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -336,14 +336,16 @@ library AsyncOrder {
 
         FeeTier.Data storage feeTier = FeeTier.load(account.feeTierId);
 
-        runtime.orderFees =
-            calculateOrderFee(
-                runtime.sizeDelta,
-                runtime.fillPrice,
-                perpsMarketData.skew,
-                FeeTier.getFees(feeTier, marketConfig.orderFees)
-            ) +
-            settlementRewardCost(strategy);
+        runtime.orderFees = calculateOrderFee(
+            runtime.sizeDelta,
+            runtime.fillPrice,
+            perpsMarketData.skew,
+            FeeTier.getFees(feeTier, marketConfig.orderFees)
+        );
+        if (marketConfig.orderFees.makerFee > 0 || marketConfig.orderFees.takerFee > 0) {
+            // Add settlement reward for markets with non-zero fee
+            runtime.orderFees += settlementRewardCost(strategy);
+        }
 
         oldPosition = PerpsMarket.accountPosition(runtime.marketId, runtime.accountId);
         runtime.newPositionSize = oldPosition.size + runtime.sizeDelta;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected fee handling for async order settlement: settlement rewards and fee processing now occur only when fees are non-zero, preventing unintended charges in zero-fee configurations.
  - Ensures order fees are calculated accurately and settlement behavior remains consistent when fees are zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->