### PR TITLE
Setup withdrawal locks

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IAccountModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IAccountModule.sol
@@ -253,7 +253,7 @@ interface IAccountModule {
      *
      * Requirements:
      *
-     * - `ERC2771Context._msgSender()` must have appropriate permissions (typically admin).
+     * - `ERC2771Context._msgSender()` must be the contract owner.
      *
      * Emits a {WithdrawalLockWhitelistUpdated} event.
      */

--- a/protocol/synthetix/contracts/interfaces/IAccountModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IAccountModule.sol
@@ -22,6 +22,11 @@ interface IAccountModule {
     error InvalidAccountId(uint128 accountId);
 
     /**
+     * @notice Thrown when an address that is not whitelisted attempts to set withdrawal lock.
+     */
+    error AddressNotWhitelisted(address account);
+
+    /**
      * @notice Emitted when an account token with id `accountId` is minted to `sender`.
      * @param accountId The id of the account.
      * @param owner The address that owns the created account.
@@ -54,6 +59,26 @@ interface IAccountModule {
         bytes32 indexed permission,
         address indexed user,
         address sender
+    );
+
+    /**
+     * @notice Emitted when withdrawal lock status is set for account `accountId` by `sender`.
+     * @param accountId The id of the account whose withdrawal lock status was set.
+     * @param locked Whether withdrawals are locked for this account.
+     * @param sender The address that set the withdrawal lock status.
+     */
+    event WithdrawalLockSet(uint128 indexed accountId, bool locked, address indexed sender);
+
+    /**
+     * @notice Emitted when an address is added or removed from the withdrawal lock whitelist.
+     * @param account The address that was added or removed from the whitelist.
+     * @param whitelisted Whether the address is now whitelisted.
+     * @param sender The address that modified the whitelist.
+     */
+    event WithdrawalLockWhitelistUpdated(
+        address indexed account,
+        bool whitelisted,
+        address indexed sender
     );
 
     /**
@@ -193,4 +218,44 @@ interface IAccountModule {
      * @return timestamp The unix timestamp of the last time a permissioned action occured with the account
      */
     function getAccountLastInteraction(uint128 accountId) external view returns (uint256 timestamp);
+
+    /**
+     * @notice Returns whether withdrawals are locked for the given account.
+     * @param accountId The account id to check.
+     * @return locked Whether withdrawals are locked for this account.
+     */
+    function getWithdrawalLocked(uint128 accountId) external view returns (bool locked);
+
+    /**
+     * @notice Sets the withdrawal lock status for the given account.
+     * @param accountId The account id whose withdrawal lock status is being set.
+     * @param locked Whether withdrawals should be locked for this account.
+     *
+     * Requirements:
+     *
+     * - `ERC2771Context._msgSender()` must be whitelisted to set withdrawal locks.
+     *
+     * Emits a {WithdrawalLockSet} event.
+     */
+    function setWithdrawalLocked(uint128 accountId, bool locked) external;
+
+    /**
+     * @notice Returns whether an address is whitelisted to set withdrawal locks.
+     * @param account The address to check.
+     * @return whitelisted Whether the address is whitelisted.
+     */
+    function isWithdrawalLockWhitelisted(address account) external view returns (bool whitelisted);
+
+    /**
+     * @notice Sets the whitelist status for an address to set withdrawal locks.
+     * @param account The address whose whitelist status is being set.
+     * @param whitelisted Whether the address should be whitelisted.
+     *
+     * Requirements:
+     *
+     * - `ERC2771Context._msgSender()` must have appropriate permissions (typically admin).
+     *
+     * Emits a {WithdrawalLockWhitelistUpdated} event.
+     */
+    function setWithdrawalLockWhitelisted(address account, bool whitelisted) external;
 }

--- a/protocol/synthetix/contracts/modules/core/AccountModule.sol
+++ b/protocol/synthetix/contracts/modules/core/AccountModule.sol
@@ -3,11 +3,13 @@ pragma solidity >=0.8.11 <0.9.0;
 
 import "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 import "@synthetixio/core-modules/contracts/storage/AssociatedSystem.sol";
+import "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 
 import "../../interfaces/IAccountModule.sol";
 import "../../interfaces/IAccountTokenModule.sol";
 import "../../storage/Account.sol";
 import "../../storage/SystemAccountConfiguration.sol";
+import "../../storage/WithdrawalLockWhitelist.sol";
 
 import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
 
@@ -195,6 +197,48 @@ contract AccountModule is IAccountModule {
      */
     function getAccountLastInteraction(uint128 accountId) external view returns (uint256) {
         return Account.load(accountId).lastInteraction;
+    }
+
+    /**
+     * @inheritdoc IAccountModule
+     */
+    function getWithdrawalLocked(uint128 accountId) public view override returns (bool) {
+        return Account.load(accountId).withdrawalLocked;
+    }
+
+    /**
+     * @inheritdoc IAccountModule
+     */
+    function setWithdrawalLocked(uint128 accountId, bool locked) external override {
+        WithdrawalLockWhitelist.Data storage whitelist = WithdrawalLockWhitelist.load();
+
+        if (!whitelist.whitelistedAddresses[ERC2771Context._msgSender()]) {
+            revert AddressNotWhitelisted(ERC2771Context._msgSender());
+        }
+
+        Account.Data storage account = Account.exists(accountId);
+        account.withdrawalLocked = locked;
+
+        emit WithdrawalLockSet(accountId, locked, ERC2771Context._msgSender());
+    }
+
+    /**
+     * @inheritdoc IAccountModule
+     */
+    function isWithdrawalLockWhitelisted(address account) public view override returns (bool) {
+        return WithdrawalLockWhitelist.load().whitelistedAddresses[account];
+    }
+
+    /**
+     * @inheritdoc IAccountModule
+     */
+    function setWithdrawalLockWhitelisted(address account, bool whitelisted) external override {
+        OwnableStorage.onlyOwner();
+
+        WithdrawalLockWhitelist.Data storage whitelist = WithdrawalLockWhitelist.load();
+        whitelist.whitelistedAddresses[account] = whitelisted;
+
+        emit WithdrawalLockWhitelistUpdated(account, whitelisted, ERC2771Context._msgSender());
     }
 
     /**

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -80,6 +80,10 @@ contract CollateralModule is ICollateralModule {
             Config.readUint(_CONFIG_TIMEOUT_WITHDRAW, 0)
         );
 
+        if (account.withdrawalLocked) {
+            revert Account.WithdrawalLocked(accountId);
+        }
+
         uint256 tokenAmountD18 = CollateralConfiguration
             .load(collateralType)
             .convertTokenToSystemAmount(tokenAmount);

--- a/protocol/synthetix/contracts/storage/Account.sol
+++ b/protocol/synthetix/contracts/storage/Account.sol
@@ -68,6 +68,10 @@ library Account {
         uint64 __slotAvailableForFutureUse;
         uint128 __slot2AvailableForFutureUse;
         /**
+         * @dev Whether withdrawals are locked for this account.
+         */
+        bool withdrawalLocked;
+        /**
          * @dev Address set of collaterals that are being used in the system by this account.
          */
         mapping(address => Collateral.Data) collaterals;

--- a/protocol/synthetix/contracts/storage/Account.sol
+++ b/protocol/synthetix/contracts/storage/Account.sol
@@ -43,6 +43,11 @@ library Account {
     );
 
     /**
+     * @dev Thrown when a withdrawal is attempted on an account that has withdrawals locked.
+     */
+    error WithdrawalLocked(uint128 accountId);
+
+    /**
      * @notice Emitted when all the locks in an account were scaled down proportionally due to insufficient balance
      * @param totalDepositedD18 The observed deposited collateral
      * @param totalLockedD18 The observed locked collateral total
@@ -68,13 +73,13 @@ library Account {
         uint64 __slotAvailableForFutureUse;
         uint128 __slot2AvailableForFutureUse;
         /**
-         * @dev Whether withdrawals are locked for this account.
-         */
-        bool withdrawalLocked;
-        /**
          * @dev Address set of collaterals that are being used in the system by this account.
          */
         mapping(address => Collateral.Data) collaterals;
+        /**
+         * @dev Whether withdrawals are locked for this account.
+         */
+        bool withdrawalLocked;
     }
 
     /**

--- a/protocol/synthetix/contracts/storage/WithdrawalLockWhitelist.sol
+++ b/protocol/synthetix/contracts/storage/WithdrawalLockWhitelist.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+/**
+ * @title System wide whitelist for addresses that can set withdrawal locks.
+ */
+library WithdrawalLockWhitelist {
+    bytes32 private constant _SLOT_WITHDRAWAL_LOCK_WHITELIST =
+        keccak256(abi.encode("io.synthetix.synthetix.WithdrawalLockWhitelist"));
+
+    struct Data {
+        /**
+         * @dev Mapping of addresses that are whitelisted to set withdrawal locks.
+         */
+        mapping(address => bool) whitelistedAddresses;
+    }
+
+    /**
+     * @dev Returns the whitelist singleton.
+     */
+    function load() internal pure returns (Data storage whitelist) {
+        bytes32 s = _SLOT_WITHDRAWAL_LOCK_WHITELIST;
+        assembly {
+            whitelist.slot := s
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account withdrawal lock controls so authorized addresses can lock/unlock withdrawals per account.
  * Added management of a whitelist to control who may change lock status.
  * Added queries to check an account's withdrawal-locked and whitelist status.

* **Bug Fixes**
  * Withdrawals now fail early when an account is locked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->